### PR TITLE
prevent exceptions from being overwritten silently

### DIFF
--- a/eisen/utils/workflows/workflows.py
+++ b/eisen/utils/workflows/workflows.py
@@ -93,6 +93,8 @@ class EpochDataAggregator:
                     pass
 
     def __exit__(self, *args, **kwargs):
+        if any([isinstance(x, Exception) for x in args]):
+            return
         for typ in ['losses', 'metrics']:
             for i in range(len(self.epoch_data[typ])):
                 for key in self.epoch_data[typ][i].keys():


### PR DESCRIPTION
Eisen Workflows are masking/overwriting tracebacks which occur in the workflow code if the exit function also raises an error.
There is probably a way to do a more targeted check for Exceptions if there's ever a reason to be intentionally passing Exceptions to the exit function, but this fixes the traceback issue for now.