### PR TITLE
bugfix: dictionary reference error

### DIFF
--- a/eisen/utils/workflows/workflows.py
+++ b/eisen/utils/workflows/workflows.py
@@ -49,7 +49,7 @@ class EpochDataAggregator:
 
         for typ in ["losses", "metrics"]:
             if typ not in self.epoch_data.keys():
-                self.epoch_data[typ] = [{}] * len(output_dictionary[typ])
+                self.epoch_data[typ] = [{} for _ in range(len(output_dictionary[typ]))]
 
             for i in range(len(output_dictionary[typ])):
                 for key in output_dictionary[typ][i].keys():


### PR DESCRIPTION
This list contains a reference to a single dictionary object, so multiplying the list creates a list of N references to this same dictionary object, breaking EpochDataAggregator for multiple losses.  Using a comprehension instead fixes it.