### PR TITLE
Native AMP enabled to reduce the memory footprint.

### DIFF
--- a/eisen/utils/workflows/training.py
+++ b/eisen/utils/workflows/training.py
@@ -6,7 +6,7 @@ from eisen.utils import merge_two_dicts
 from eisen.utils.workflows.workflows import GenericWorkflow, EpochDataAggregator
 
 from torch import Tensor
-from torch.cuda.amp import GradScaler  # , autocast
+from torch.cuda.amp import GradScaler, autocast
 
 from pydispatch import dispatcher
 
@@ -248,9 +248,9 @@ class TrainingAMP(Training):
 
         self.optimizer.zero_grad()
 
-        # with autocast():
-        outputs = self.model(**model_argument_dict)
-        losses = self.compute_losses(merge_two_dicts(batch, outputs))
+        with autocast():
+            outputs = self.model(**model_argument_dict)
+            losses = self.compute_losses(merge_two_dicts(batch, outputs))
 
         for loss in losses:
             for key in loss.keys():


### PR DESCRIPTION
As mentioned in #34, PyTorch 1.6.0 is now natively supporting AMP, and hence, the relevant lines have been uncommented. 